### PR TITLE
support to run 64 bit assembly and support for future MSTest provider

### DIFF
--- a/ParallelTestRunner.Tests/ParallelTestRunner.Tests.csproj
+++ b/ParallelTestRunner.Tests/ParallelTestRunner.Tests.csproj
@@ -33,6 +33,26 @@
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>

--- a/ParallelTestRunner.sln
+++ b/ParallelTestRunner.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UITests", "UITests\UITests.csproj", "{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}"
 EndProject
@@ -12,21 +12,35 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Debug|x64.ActiveCfg = Debug|x64
+		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Debug|x64.Build.0 = Debug|x64
 		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Release|x64.ActiveCfg = Release|x64
+		{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}.Release|x64.Build.0 = Release|x64
 		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Debug|x64.ActiveCfg = Debug|x64
+		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Debug|x64.Build.0 = Debug|x64
 		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Release|x64.ActiveCfg = Release|x64
+		{7221E662-3C84-4FEF-81A1-0E486F3C2CE0}.Release|x64.Build.0 = Release|x64
 		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Debug|x64.ActiveCfg = Debug|x64
+		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Debug|x64.Build.0 = Debug|x64
 		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Release|x64.ActiveCfg = Release|x64
+		{5D5AEB33-19A7-4073-ACEC-64A1D79624A5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ParallelTestRunner.sln
+++ b/ParallelTestRunner.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UITests", "UITests\UITests.csproj", "{3374B9F8-2C73-42D9-B8D4-BF675FFB4FB7}"
 EndProject

--- a/ParallelTestRunner/Common/Impl/ResultNotfoundException.cs
+++ b/ParallelTestRunner/Common/Impl/ResultNotfoundException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ParallelTestRunner.Common.Impl
+{
+    class ResultNotfoundException: Exception
+    {
+    }
+}

--- a/ParallelTestRunner/Common/Impl/WindowsFileHelperImpl.cs
+++ b/ParallelTestRunner/Common/Impl/WindowsFileHelperImpl.cs
@@ -23,7 +23,10 @@ namespace ParallelTestRunner.Common.Impl
 
         public string GetFile(string folder, string ext)
         {
-            return Directory.GetFiles(folder, "*.trx")[0];
+            string[] files = Directory.GetFiles(folder, "*.trx");
+            if (files.Length == 0)
+                throw new ResultNotfoundException();
+            return files[0];
         }
 
         public Stream OpenFile(string path)

--- a/ParallelTestRunner/Impl/TestRunnerArgsImpl.cs
+++ b/ParallelTestRunner/Impl/TestRunnerArgsImpl.cs
@@ -28,7 +28,17 @@ namespace ParallelTestRunner.Impl
 
         public string GetExecutablePath()
         {
-            return ConfigurationManager.AppSettings.Get(Provider);
+            string exePath = ConfigurationManager.AppSettings.Get(Provider);
+            if(string.IsNullOrEmpty(exePath))
+            {
+                // try to get it from env variable
+                exePath = Environment.GetEnvironmentVariable(Provider);
+            }
+            if (string.IsNullOrEmpty(exePath))
+            {
+                throw new Exception("Couldn't find provide for " + Provider + ". Please check the provider or set envrionment variable " + Provider + " to point to the path of vstest.console.exe");
+            }
+            return exePath;
         }
 
         public bool IsValid()

--- a/ParallelTestRunner/ParallelTestRunner.csproj
+++ b/ParallelTestRunner/ParallelTestRunner.csproj
@@ -35,6 +35,30 @@
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;TRACE;DEBUG</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <CodeAnalysisIgnoreGeneratedCode>false</CodeAnalysisIgnoreGeneratedCode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
@@ -53,6 +77,7 @@
     <Compile Include="Autofac\AutofacContainer.cs" />
     <Compile Include="Common\IExecutorThread.cs" />
     <Compile Include="Common\Impl\ExecutorThreadImpl.cs" />
+    <Compile Include="Common\Impl\ResultNotfoundException.cs" />
     <Compile Include="Common\Impl\StopwatchImpl.cs" />
     <Compile Include="Common\Impl\SummaryCalculatorImpl.cs" />
     <Compile Include="Common\Impl\ThreadFactoryImpl.cs" />
@@ -136,7 +161,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/ParallelTestRunner/VSTest/Common/Impl/VSTestFileHelperImpl.cs
+++ b/ParallelTestRunner/VSTest/Common/Impl/VSTestFileHelperImpl.cs
@@ -11,10 +11,11 @@ namespace ParallelTestRunner.VSTest.Common.Impl
         public void CreateSettingsFile(RunData data)
         {
             string settingFileName = string.Concat(data.Root, "\\", data.RunId, ".settings");
+            string platform = System.Environment.Is64BitProcess ? "x64" : "x86";
             string settingsFileContent = string.Concat(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RunSettings><RunConfiguration><ResultsDirectory>",
                 data.RunId,
-                "</ResultsDirectory></RunConfiguration></RunSettings>");
+                "</ResultsDirectory><TargetPlatform>"+platform+"</TargetPlatform></RunConfiguration></RunSettings>");
 
             WindowsFileHelper.WriteFile(settingFileName, settingsFileContent);
         }

--- a/ParallelTestRunner/VSTest/Impl/VSTestCollectorImpl.cs
+++ b/ParallelTestRunner/VSTest/Impl/VSTestCollectorImpl.cs
@@ -2,6 +2,7 @@
 using ParallelTestRunner.Common;
 using ParallelTestRunner.Common.Trx;
 using ParallelTestRunner.VSTest.Common;
+using ParallelTestRunner.Common.Impl;
 
 namespace ParallelTestRunner.VSTest.Impl
 {
@@ -17,10 +18,17 @@ namespace ParallelTestRunner.VSTest.Impl
 
             foreach (RunData item in items)
             {
-                using (var stream = FileHelper.OpenTrxFile(item))
+                try
                 {
-                    var file = TrxParser.Parse(stream);
-                    trxFileList.Add(file);
+                    using (var stream = FileHelper.OpenTrxFile(item))
+                    {
+                        var file = TrxParser.Parse(stream);
+                        trxFileList.Add(file);
+                    }
+                }
+                catch (ResultNotfoundException ex)
+                {
+                    //TODO log message?
                 }
             }
 

--- a/UITests/UITests.csproj
+++ b/UITests/UITests.csproj
@@ -32,6 +32,26 @@
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />


### PR DESCRIPTION
Few minor changes
1) support to run 64 bit assembly 
2) Option to specify the provider via env variable ( I found that different flavors of vs2017 is installed in different folder, so cannot specify a hard coded path in config)
3) A minor crash fix that was happening when the test didn't produce any result,